### PR TITLE
Add remote monitoring to examples

### DIFF
--- a/examples/cassandra.yaml
+++ b/examples/cassandra.yaml
@@ -52,7 +52,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: 
+              command:
               - /bin/sh
               - -c
               - nodetool drain
@@ -112,6 +112,7 @@ data:
         - name: cassandra-metrics
           command: metrics
           arguments:
+              remote_monitoring: true
               hostname: localhost
               port: 7199
           labels:

--- a/examples/mysql.yaml
+++ b/examples/mysql.yaml
@@ -51,6 +51,7 @@ data:
           port: 3306
           username: root
           password: $MYSQL_ROOT_PASSWORD
+          remote_monitoring: true
         labels:
           env: testenv
           role: write-replica

--- a/examples/nginx.yaml
+++ b/examples/nginx.yaml
@@ -78,6 +78,7 @@ data:
           command: metrics
           arguments:
               status_url: http://127.0.0.1/status
+              remote_monitoring: true
           labels:
               env: production
               role: load_balancer
@@ -85,6 +86,7 @@ data:
           command: inventory
           arguments:
               config_path: /etc/nginx/nginx.conf
+              remote_monitoring: true
           labels:
               env: production
               role: load_balancer
@@ -105,4 +107,3 @@ data:
               - -inventory
             prefix: config/nginx
             interval: 60
-

--- a/examples/redis.yaml
+++ b/examples/redis.yaml
@@ -35,6 +35,7 @@ data:
         arguments:
           hostname: localhost
           port: 6379
+          remote_monitoring: true
         labels:
           environment: production
       - name: redis-inventory
@@ -42,6 +43,7 @@ data:
         arguments:
           hostname: localhost
           port: 6379
+          remote_monitoring: true
         labels:
           environment: production
   definition.yaml: |


### PR DESCRIPTION
Adds the new `remote_monitoring` option for the integrations updated to SDK V3 in the examples