### PR TITLE
Typo on configMap name

### DIFF
--- a/examples/mongodb.yaml
+++ b/examples/mongodb.yaml
@@ -405,7 +405,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: mongodb-cfg-newrelic-integrations-config
+  name: mongodb-newrelic-integrations-config
   namespace: default
 data:
   config.yaml: |


### PR DESCRIPTION
renamed mongodb-cfg-newrelic-integrations-config to mongodb-newrelic-integrations-config