### PR TITLE
Inject display-name in sidecars with node-name value

### DIFF
--- a/src/server/env_vars.go
+++ b/src/server/env_vars.go
@@ -27,6 +27,7 @@ func (m *metadataEnvGenerator) getVars(pod *corev1.Pod, container *corev1.Contai
 		createEnvVarFromFieldPath("NEW_RELIC_METADATA_KUBERNETES_POD_NAME", "metadata.name"),
 		createEnvVarFromString("NEW_RELIC_METADATA_KUBERNETES_CONTAINER_NAME", container.Name),
 		createEnvVarFromString("NEW_RELIC_METADATA_KUBERNETES_CONTAINER_IMAGE_NAME", container.Image),
+		createEnvVarFromFieldPath("NRIA_DISPLAY_NAME", "spec.nodeName"),
 	}
 
 	if len(pod.OwnerReferences) == 1 {

--- a/src/server/testdata/expectedEnvVarsAdmissionReviewPatch.json
+++ b/src/server/testdata/expectedEnvVarsAdmissionReviewPatch.json
@@ -65,6 +65,18 @@
     "op": "add",
     "path": "/spec/containers/0/env/-",
     "value": {
+      "name": "NRIA_DISPLAY_NAME",
+      "valueFrom": {
+        "fieldRef": {
+          "fieldPath": "spec.nodeName"
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/env/-",
+    "value": {
       "name": "NEW_RELIC_METADATA_KUBERNETES_DEPLOYMENT_NAME",
       "value": "test"
     }
@@ -129,6 +141,18 @@
     "value": {
       "name": "NEW_RELIC_METADATA_KUBERNETES_CONTAINER_IMAGE_NAME",
       "value": "newrelic/image2:1.0.0"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/1/env/-",
+    "value": {
+      "name": "NRIA_DISPLAY_NAME",
+      "valueFrom": {
+        "fieldRef": {
+          "fieldPath": "spec.nodeName"
+        }
+      }
     }
   },
   {

--- a/src/server/testdata/expectedSidecarAdmissionReviewPatch.json
+++ b/src/server/testdata/expectedSidecarAdmissionReviewPatch.json
@@ -175,6 +175,14 @@
                     }
                 },
                 {
+                    "name": "NRIA_DISPLAY_NAME",
+                    "valueFrom": {
+                        "fieldRef": {
+                            "fieldPath": "spec.nodeName"
+                        }
+                    }
+                },
+                {
                     "name": "NEW_RELIC_METADATA_KUBERNETES_CONTAINER_NAME",
                     "value": "c1"
                 },

--- a/src/server/testdata/expectedSidecarAdmissionReviewPatch.json
+++ b/src/server/testdata/expectedSidecarAdmissionReviewPatch.json
@@ -199,20 +199,20 @@
                     }
                 },
                 {
-                    "name": "NRIA_DISPLAY_NAME",
-                    "valueFrom": {
-                        "fieldRef": {
-                            "fieldPath": "spec.nodeName"
-                        }
-                    }
-                },
-                {
                     "name": "NEW_RELIC_METADATA_KUBERNETES_CONTAINER_NAME",
                     "value": "c1"
                 },
                 {
                     "name": "NEW_RELIC_METADATA_KUBERNETES_CONTAINER_IMAGE_NAME",
                     "value": "newrelic/image:latest"
+                },
+                {
+                    "name": "NRIA_DISPLAY_NAME",
+                    "valueFrom": {
+                        "fieldRef": {
+                            "fieldPath": "spec.nodeName"
+                        }
+                    }
                 },
                 {
                     "name": "NEW_RELIC_METADATA_KUBERNETES_DEPLOYMENT_NAME",

--- a/src/server/testdata/expectedSidecarAdmissionReviewPatch.json
+++ b/src/server/testdata/expectedSidecarAdmissionReviewPatch.json
@@ -65,6 +65,18 @@
         "op": "add",
         "path": "/spec/containers/0/env/-",
         "value": {
+            "name": "NRIA_DISPLAY_NAME",
+            "valueFrom": {
+                "fieldRef": {
+                    "fieldPath": "spec.nodeName"
+                }
+            }
+        }
+    },
+    {
+        "op": "add",
+        "path": "/spec/containers/0/env/-",
+        "value": {
             "name": "NEW_RELIC_METADATA_KUBERNETES_DEPLOYMENT_NAME",
             "value": "test"
         }
@@ -129,6 +141,18 @@
         "value": {
             "name": "NEW_RELIC_METADATA_KUBERNETES_CONTAINER_IMAGE_NAME",
             "value": "newrelic/image2:1.0.0"
+        }
+    },
+    {
+        "op": "add",
+        "path": "/spec/containers/1/env/-",
+        "value": {
+            "name": "NRIA_DISPLAY_NAME",
+            "valueFrom": {
+                "fieldRef": {
+                    "fieldPath": "spec.nodeName"
+                }
+            }
         }
     },
     {

--- a/src/server/webhook_test.go
+++ b/src/server/webhook_test.go
@@ -51,7 +51,7 @@ func loadTestData(t *testing.T, name string) []byte {
 
 func TestServeHTTP(t *testing.T) {
 	expectedEnvVarsPatchForValidBody := loadTestData(t, "expectedEnvVarsAdmissionReviewPatch.json")
-	//expectedSidecarPatchForValidBody := loadTestData(t, "expectedSidecarAdmissionReviewPatch.json")
+	expectedSidecarPatchForValidBody := loadTestData(t, "expectedSidecarAdmissionReviewPatch.json")
 	missingObjectRequestBody := bytes.Replace(makeTestData(t, "default", map[string]string{}), []byte("\"object\""), []byte("\"foo\""), -1)
 
 	patchTypeForValidBody := v1beta1.PatchTypeJSONPatch
@@ -120,22 +120,21 @@ func TestServeHTTP(t *testing.T) {
 			expectedStatusCode:        http.StatusBadRequest,
 			expectedBodyWhenHTTPError: fmt.Sprintf("object not present in request body: %q\n", missingObjectRequestBody),
 		},
-		// TODO fix test case
-		//{
-		//	name:               "sidecar mutation applied - with sidecar",
-		//	requestBody:        makeTestData(t, "default", map[string]string{"newrelic.com/integrations-sidecar-configmap": configName}),
-		//	contentType:        "application/json",
-		//	expectedStatusCode: http.StatusOK,
-		//	expectedAdmissionReview: v1beta1.AdmissionReview{
-		//		Response: &v1beta1.AdmissionResponse{
-		//			UID:       types.UID(1),
-		//			Allowed:   true,
-		//			Result:    nil,
-		//			Patch:     expectedSidecarPatchForValidBody,
-		//			PatchType: &patchTypeForValidBody,
-		//		},
-		//	},
-		//},
+		{
+			name:               "sidecar mutation applied - with sidecar",
+			requestBody:        makeTestData(t, "default", map[string]string{"newrelic.com/integrations-sidecar-configmap": configName}),
+			contentType:        "application/json",
+			expectedStatusCode: http.StatusOK,
+			expectedAdmissionReview: v1beta1.AdmissionReview{
+				Response: &v1beta1.AdmissionResponse{
+					UID:       types.UID(1),
+					Allowed:   true,
+					Result:    nil,
+					Patch:     expectedSidecarPatchForValidBody,
+					PatchType: &patchTypeForValidBody,
+				},
+			},
+		},
 		{
 			name:                      "sidecar mutation - wrong config map name",
 			requestBody:               makeTestData(t, "default", map[string]string{"newrelic.com/integrations-sidecar-configmap": "wrong"}),


### PR DESCRIPTION
Inject display-name agent property for sidecars bundling node-name as value for sidecars to use same entity as K8s integration

To do:
- [x] Fix tests

Nice to have:
- [x] Json diff view on test equality assertion failure (current error output is mostly useless)