### PR TITLE
Retry on configmap not found

### DIFF
--- a/src/server/sidecar.go
+++ b/src/server/sidecar.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"strings"
 
@@ -71,17 +70,19 @@ func NewSidecarMutator(clusterName string, cfgMapRtrv configMapRetriever) *Sidec
 	return sm
 }
 
-type mutateError struct {
-	message string
-	code    int
+// ConfigMapNotFoundErr config map was not found
+type ConfigMapNotFoundErr struct {
+	configMapName string
 }
 
-func (me mutateError) Error() string {
-	return me.message
+// Error returns the error message.
+func (e ConfigMapNotFoundErr) Error() string {
+	return "config map not found"
 }
 
-func (me mutateError) Code() int {
-	return me.code
+// ConfigMapName returns config map name.
+func (e ConfigMapNotFoundErr) ConfigMapName() string {
+	return e.configMapName
 }
 
 // (https://github.com/kubernetes/kubernetes/issues/57982)
@@ -262,9 +263,8 @@ func (sm *SidecarMutator) createSidecar(pod *corev1.Pod) ([]corev1.Container, []
 	cfgMap, err := sm.cfgMapRtrv.ConfigMap(pod.Namespace, configMapName)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
-			return nil, nil, &mutateError{
-				message: fmt.Sprintf("config map: '%s', not found", configMapName),
-				code:    http.StatusBadRequest,
+			return nil, nil, &ConfigMapNotFoundErr{
+				configMapName: configMapName,
 			}
 		}
 		return nil, nil, errors.Wrapf(err, "error retrieving config map '%s'", configMapName)

--- a/src/server/webhook.go
+++ b/src/server/webhook.go
@@ -25,6 +25,7 @@ import (
 
 const (
 	maxMutationRetries = 10
+	mutationRetryDelay = 500 * time.Millisecond
 )
 
 var (
@@ -172,7 +173,7 @@ func (whsvr *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					if cErr, ok := err.(*ConfigMapNotFoundErr); ok {
 						retries++
 						whsvr.Logger.Warnw("config map not found during mutation, retrying", "configmap", cErr.ConfigMapName())
-						time.Sleep(500 * time.Millisecond)
+						time.Sleep(mutationRetryDelay)
 						goto retryMutate
 					}
 				}

--- a/src/server/webhook.go
+++ b/src/server/webhook.go
@@ -91,8 +91,8 @@ type code interface {
 }
 
 func errorCode(err error) int {
-	if me, ok := err.(code); ok {
-		return me.Code()
+	if _, ok := err.(*ConfigMapNotFoundErr); ok {
+		return http.StatusBadRequest
 	}
 	return http.StatusInternalServerError
 }

--- a/src/server/webhook_test.go
+++ b/src/server/webhook_test.go
@@ -137,7 +137,7 @@ func TestServeHTTP(t *testing.T) {
 			requestBody:               makeTestData(t, "default", map[string]string{"newrelic.com/integrations-sidecar-configmap": "wrong"}),
 			contentType:               "application/json",
 			expectedStatusCode:        http.StatusBadRequest,
-			expectedBodyWhenHTTPError: fmt.Sprintf("error during mutation: \"config map: 'wrong', not found\"\n"),
+			expectedBodyWhenHTTPError: fmt.Sprintf("error during mutation: \"%s\"\n", ConfigMapNotFoundErr{}.Error()),
 		},
 	}
 


### PR DESCRIPTION
Sidecar creation might fail during mutation on slow systems, meanwhile configmap is not available.

This adds a retry (with limited amount of attempts) to eventually overcome this inconsistency.

ToDo:
- [x] Fix tests