### PR TITLE
Sidecars breaking HPA autoscaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,11 +233,11 @@ The New Relic sidecar will have defined by default values for CPU and memory res
 
 You should take those values into account when defining the auto scaling target threshold.
 
-`new_target = Floor(old_target * limit / (limit + sidecar_limit)]`
+`new_target = Floor(old_target * request / (request + sidecar_request)]`
 
 e.g.
 
-*  You have defined a container CPU limit of `1000m` and a pod `targetCPUUtilizationPercentage` of `90%`
+*  You have defined a container CPU request of `1000m` and a pod `targetCPUUtilizationPercentage` of `90%`
 You should adjust the `targetCPUUtilizationPercentage` to: Floor(90 * 1000 / 1100)) = `81%`
 
 ### Run

--- a/README.md
+++ b/README.md
@@ -225,20 +225,18 @@ Currently for K8s libraries it uses version 1.13.1. Only couple of libraries are
 
 #### Configuring Horizontal Pod Autoscaler
 
-If you have defined a HPA for a pod that will be monitored with New Relic Infrastructure Agent, you will have to take into account the New Relic sidecar resources requests when defining the auto scaling threshold. This is because the resources requests are set on the container level while the auto scaling threshold is set on pod.
+If you have defined a HPA for a pod that will be monitored with New Relic Infrastructure Agent, you will have to take into account the New Relic sidecar resource request/limit when defining the auto scaling threshold. This is because the resource request/limit are set on the container level while the auto scaling threshold is set on pod. For more information read the [official documentation](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container) for Resource requests and limits of Pod and Container.
 
-The New Relic sidecar will have defined by default values for CPU and memory resources requests:
+The New Relic sidecar will have defined by default values for CPU and memory resource request/limit:
  * `cpu: "100m"`
  * `memory: "64Mi"`
 
-You should take those values into account when defining the auto scaling target threshold.
-
-`new_target = Floor(old_target * request / (request + sidecar_request)]`
+We suggest to take those values into account when defining the auto scaling target threshold.
 
 e.g.
 
 *  You have defined a container CPU request of `1000m` and a pod `targetCPUUtilizationPercentage` of `90%`
-You should adjust the `targetCPUUtilizationPercentage` to: Floor(90 * 1000 / 1100)) = `81%`
+we suggest that you adjust the `targetCPUUtilizationPercentage` to: Floor(90 * 1000 / 1100)) = `81%`
 
 ### Run
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,23 @@ Currently for K8s libraries it uses version 1.13.1. Only couple of libraries are
 * Edit the file and set the following value as container image: `internal/newrelic-webhook-injector`.
 * Make sure that `imagePullPolicy: Always` is not present in the file (otherwise, the image won't be pulled).
 
+#### Configuring Horizontal Pod Autoscaler
+
+If you have defined a HPA for a pod that will be monitored with New Relic Infrastructure Agent, you will have to take into account the New Relic sidecar resources requests when defining the auto scaling threshold. This is because the resources requests are set on the container level while the auto scaling threshold is set on pod.
+
+The New Relic sidecar will have defined by default values for CPU and memory resources requests:
+ * `cpu: "100m"`
+ * `memory: "64Mi"`
+
+You should take those values into account when defining the auto scaling target threshold.
+
+`new_target = Floor(old_target * limit / (limit + sidecar_limit)]`
+
+e.g.
+
+*  You have defined a container CPU limit of `1000m` and a pod `targetCPUUtilizationPercentage` of `90%`
+You should adjust the `targetCPUUtilizationPercentage` to: Floor(90 * 1000 / 1100)) = `81%`
+
 ### Run
 
 Run `skaffold run`. This will build a docker image, build the webhook server inside it, and finally deploy the webhook server to your Minikube and use the Kubernetes API server to sign its TLS certificate ([see section about certificates](#3-install-the-certificates)).

--- a/src/server/sidecar.go
+++ b/src/server/sidecar.go
@@ -11,6 +11,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -70,6 +71,16 @@ func NewSidecarMutator(clusterName string, cfgMapRtrv configMapRetriever) *Sidec
 				RunAsNonRoot:             boolPointer(true),
 				ReadOnlyRootFilesystem:   boolPointer(false),
 				RunAsUser:                int64Pointer(1000),
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("64Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("64Mi"),
+				},
 			},
 		},
 		envGenerator: &metadataEnvGenerator{


### PR DESCRIPTION
Provide CU/mem limits defaults for sidecars in order to not break Horizontal Pod Autoscaler.